### PR TITLE
Fix CoT Type for Unknown Vessels

### DIFF
--- a/task.ts
+++ b/task.ts
@@ -177,7 +177,7 @@ export default class Task extends ETL {
             }
         }
         
-        if (!shipType) return { type: `a-${affiliation}-S` };
+        if (!shipType) return { type: `a-${affiliation}-S-X` };
         
         const mapping = AIS_TYPE_TO_COT[shipType];
         if (mapping) {
@@ -199,7 +199,7 @@ export default class Task extends ETL {
         // 80-89: Tankers
         if (shipType >= 80 && shipType <= 89) return { type: `a-${affiliation}-S-X-M-O` };
         
-        return { type: `a-${affiliation}-S` };
+        return { type: `a-${affiliation}-S-X` };
     }
 
     private getNavigationalStatusText(status?: number): string {


### PR DESCRIPTION
### Problem
- Vessels without AIS ship type data were using generic `a-n-S` designation
- This provided insufficient tactical information for operational awareness

### Solution
- Updated unknown vessel fallback from `a-n-S` to `a-n-S-X` (civilian surface contact)
- Maintains neutral affiliation while providing clearer vessel classification
- Consistent with civilian vessel designation patterns

### Impact
- Unknown vessels now display with appropriate civilian tactical symbols
- Better situational awareness for vessels with missing AIS type data
- Consistent CoT type hierarchy across all vessel classifications
